### PR TITLE
Bump minor version number after confirming resolve fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tn93",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A Javascript implementation of the TN93 genetic distance algorithm",
   "main": "dist/tn93.js",
   "directories": {


### PR DESCRIPTION
This increases the version number to 0.3.3 for release to npm.